### PR TITLE
add status param to submit function

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -18,6 +18,7 @@ type ClientParams = {
 type RequestParams = {
   key?: string;
   results?: {};
+  status?: string;
   token: string;
   value?: string;
 }
@@ -72,9 +73,10 @@ function AngelListAppstoreApiClient({ apiKey, apiUrl, appSlug, userId }: ClientP
     return makeRequest(`${apiUrl}/set`, body);
   };
 
-  const submit = async ({ results, token }: RequestParams) => {
+  const submit = async ({ results, status, token }: RequestParams) => {
     const body = {
       results,
+      status,
       token,
     };
 


### PR DESCRIPTION
3rd party app should send "complete" or "incomplete" as a `status` so that we can track sessions of both types.